### PR TITLE
Force image uploads to be stored publicly

### DIFF
--- a/src/Http/Livewire/EditorJS.php
+++ b/src/Http/Livewire/EditorJS.php
@@ -80,8 +80,6 @@ class EditorJS extends Component
             })
             ->first();
 
-        if (config("filesystems.disks.$this->uploadDisk.driver") == 's3' &&
-            config("filesystems.disks.$this->uploadDisk.visibility", 'private') == 'private') {
             // When no file name is passed, we use the hashName of the tmp file
             $storedFileName = $tmpFile->storePubliclyAs(
                 '/'.$this->imagesPath,
@@ -92,17 +90,6 @@ class EditorJS extends Component
             $this->dispatchBrowserEvent($eventName, [
                 'url' => Storage::disk($this->uploadDisk)->url($storedFileName),
             ]);
-        } else {
-            $storedFileName = $tmpFile->storeAs(
-                '/'.$this->imagesPath,
-                $fileName ?? $tmpFile->hashName(),
-                $this->uploadDisk
-            );
-    
-            $this->dispatchBrowserEvent($eventName, [
-                'url' => Storage::disk($this->uploadDisk)->url($storedFileName),
-            ]);
-        }
     }
 
     public function loadImageFromUrl(string $url)
@@ -110,7 +97,7 @@ class EditorJS extends Component
         $name = basename($url);
         $content = file_get_contents($url);
 
-        Storage::disk($this->downloadDisk)->put($name, $content);
+        Storage::disk($this->downloadDisk)->put($name, $content, 'public');
 
         return Storage::disk($this->downloadDisk)->url($name);
     }

--- a/src/Http/Livewire/EditorJS.php
+++ b/src/Http/Livewire/EditorJS.php
@@ -80,16 +80,29 @@ class EditorJS extends Component
             })
             ->first();
 
-        // When no file name is passed, we use the hashName of the tmp file
-        $storedFileName = $tmpFile->storeAs(
-            '/'.$this->imagesPath,
-            $fileName ?? $tmpFile->hashName(),
-            $this->uploadDisk
-        );
-
-        $this->dispatchBrowserEvent($eventName, [
-            'url' => Storage::disk($this->uploadDisk)->url($storedFileName),
-        ]);
+        if (config("filesystems.disks.$this->uploadDisk.driver") == 's3' &&
+            config("filesystems.disks.$this->uploadDisk.visibility", 'private') == 'private') {
+            // When no file name is passed, we use the hashName of the tmp file
+            $storedFileName = $tmpFile->storePubliclyAs(
+                '/'.$this->imagesPath,
+                $fileName ?? $tmpFile->hashName(),
+                $this->uploadDisk
+            );
+    
+            $this->dispatchBrowserEvent($eventName, [
+                'url' => Storage::disk($this->uploadDisk)->url($storedFileName),
+            ]);
+        } else {
+            $storedFileName = $tmpFile->storeAs(
+                '/'.$this->imagesPath,
+                $fileName ?? $tmpFile->hashName(),
+                $this->uploadDisk
+            );
+    
+            $this->dispatchBrowserEvent($eventName, [
+                'url' => Storage::disk($this->uploadDisk)->url($storedFileName),
+            ]);
+        }
     }
 
     public function loadImageFromUrl(string $url)


### PR DESCRIPTION
- The current implementation does not specify the visibility of uploaded files. If the driver was S3 and it was set to private visibility, then the uploaded image will be stored as private.
- This PR will force it to store the file publicly.